### PR TITLE
switch to email collection mode, CNAME passthrough

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -14,6 +14,7 @@ module.exports = function(eleventyConfig) {
 	eleventyConfig.addPassthroughCopy("src/js");
 	eleventyConfig.addPassthroughCopy("src/img");
 	eleventyConfig.addPassthroughCopy("src/files");
+	eleventyConfig.addPassthroughCopy("CNAME");
 
 	return {
 		pathPrefix: isProduction ? "" : "/mybus-v2/",

--- a/docs/allChanges/index.html
+++ b/docs/allChanges/index.html
@@ -1346,6 +1346,294 @@ rel="stylesheet">
 	vgo('process');
 </script>
 <!-- End Active Campaign tracking -->
+	<!---------------------- START FOOTER ---------------------->
+<footer>
+	<a class="l-footer--top" target="_self">
+		<span class="visually-hidden">Top of Page</span>
+		<svg class="svg-icon" role="img" height="40" width="40" focusable="false" viewBox="0 0 24 24">
+			<path
+				d="M12 1c6.1 0 11 5 11 11s-4.9 11-11 11S1 18.1 1 12 6 1 12 1m0-1C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.7 0 12 0z"
+				fill="#354ca0"></path>
+			<path
+				d="M12 1c6.1 0 11 5 11 11s-4.9 11-11 11S1 18.1 1 12 6 1 12 1m0-1C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.7 0 12 0z"
+				fill="#3c64ae"></path>
+			<path d="M12.5 7.4l3.9 4.1.6-.7-5-5.3-5 5.3.7.7 3.8-4.1v11.1h1z" fill="#3b63ae"></path>
+		</svg>
+	</a>
+	<div class="l-footer__row-1">
+		<div class="l-container">
+			<div class="site-content-wrapper">
+				<div class="row">
+					<div class="col-12 col-md-6">
+						<div class="l-footer-info">
+							<h4 class="l-footer-info__head">Bus & Rail Transit Info</h4>
+							<a href="tel:1-323-466-3876" class="l-footer-info__tel"
+								title="Call for Transit Info">323.GO.METRO <span
+									class="d-none d-sm-inline">(323.466.3876)</span></a>
+							<div class="l-footer-info__subtext">Mon-Fri 5am to 9pm <span
+									class="d-none d-sm-inline">|</span> <span class="d-block d-sm-inline">Sat/Sun
+									6am to 6pm</span></div>
+							<a href="tel:1-323-466-3876" class="l-footer-info__tel-icon d-md-none"><svg
+									class="svg-icon" role="img" height="50" width="50" focusable="false"
+									viewBox="0 0 24 24">
+									<path
+										d="M20.7 19.4c.3-.3.7-1-.1-2.1l-2.7-2.6s-.7-.7-1.7-.1l-.2.3zM9.6 8.7c.2-.1 1.1-1.2 0-2.3L6.9 3.8s-1-.7-1.9.2c0 0-.1 0-.2.1zm5.4 7.1l-.4.4s-4.4-2.3-6.2-6.2l.3-.3L4 5.2c-.5.9-1 2.3-.6 4 0 0 .1 3.4 6 8.6 0 0 3.2 2.8 6.8 3.3 0 0 1.8.4 3.5-.8z"
+										fill="#3962ae"></path>
+								</svg></a>
+						</div>
+						<div class="l-footer-info">
+							<h4 class="l-footer-info__head">Tap Customer Service</h4>
+							<a href="tel:1-866-827-8646" class="l-footer-info__tel"
+								title="Call for Transit Info">866.TAPTOGO</a>
+							<div class="l-footer-info__subtext"><span aria-hidden="true">Mon</span><span
+									class="visually-hidden">Monday</span>-<span aria-hidden="true">Fri</span><span
+									class="visually-hidden">Friday</span> 8am to 4:30pm | <a
+									href="https://www.taptogo.net" target="_blank" rel="noopener">Taptogo
+									Website</a></div>
+							<a href="tel:1-866-827-8646" class="l-footer-info__tel-icon d-md-none"><svg
+									class="svg-icon" role="img" height="50" width="50" focusable="false"
+									viewBox="0 0 24 24">
+									<path
+										d="M20.7 19.4c.3-.3.7-1-.1-2.1l-2.7-2.6s-.7-.7-1.7-.1l-.2.3zM9.6 8.7c.2-.1 1.1-1.2 0-2.3L6.9 3.8s-1-.7-1.9.2c0 0-.1 0-.2.1zm5.4 7.1l-.4.4s-4.4-2.3-6.2-6.2l.3-.3L4 5.2c-.5.9-1 2.3-.6 4 0 0 .1 3.4 6 8.6 0 0 3.2 2.8 6.8 3.3 0 0 1.8.4 3.5-.8z"
+										fill="#3962ae"></path>
+								</svg></a>
+						</div>
+						<div class="l-footer-info">
+							<h4 class="l-footer-info__head">Transit Watch <span class="d-inline"
+									aria-hidden="true">Metro Security</span></h4>
+							<a href="tel:1-888-950-7233" class="l-footer-info__tel"
+								title="Call for Transit Info">888.950.7233</a>
+							<div class="l-footer-info__subtext">24 hours | <a href="#">Report an Issue</a></div>
+							<a href="tel:1-888-950-7233" class="l-footer-info__tel-icon d-md-none"><svg
+									class="svg-icon" role="img" height="50" width="50" focusable="false"
+									viewBox="0 0 24 24">
+									<path
+										d="M20.7 19.4c.3-.3.7-1-.1-2.1l-2.7-2.6s-.7-.7-1.7-.1l-.2.3zM9.6 8.7c.2-.1 1.1-1.2 0-2.3L6.9 3.8s-1-.7-1.9.2c0 0-.1 0-.2.1zm5.4 7.1l-.4.4s-4.4-2.3-6.2-6.2l.3-.3L4 5.2c-.5.9-1 2.3-.6 4 0 0 .1 3.4 6 8.6 0 0 3.2 2.8 6.8 3.3 0 0 1.8.4 3.5-.8z"
+										fill="#3962ae"></path>
+								</svg></a>
+						</div>
+					</div>
+					<div class="col-12 col-md-6">
+						<div class="row l-footer-linksets">
+							<div class="col-12 col-md-6 l-footer-linkset">
+								<nav>
+									<h4 class="js-footer-linkset-toggle">
+										<span>Agency Links...</span>
+										<svg class="svg-icon d-inline-block d-md-none" role="img" height="30"
+											width="30" focusable="false" viewBox="0 0 20 20">
+											<path d="M10 12.6L15.3 7l.7.7-6 6.3-6-6.3.7-.7z" fill="#3962ae"></path>
+										</svg>
+									</h4>
+									<ul class="l-footer-linkset__list" style="display: none;">
+										<li><a href="https://www.metro.net/about/contact/" target="_self">Help &amp;
+												Contacts</a></li>
+										<li><a href="https://www.metro.net/about/contact/#customer-centers"
+												target="_self">Customer
+												Centers</a></li>
+										<li><a href="https://www.metro.net/about/careers/" target="_self">Metro
+												Careers</a></li>
+										<li><a href="https://boardagendas.metro.net/" target="_blank">Board
+												Meetings</a></li>
+										<li><a href="https://www.metro.net/about/board/recap-actions/"
+												target="_self">Board Recap of
+												Actions</a></li>
+										<li><a href="https://www.metro.net/news/media-relations-contact-information/"
+												target="_self">Media</a></li>
+										<li><a href="https://www.metrobonds.net" target="_blank">Investor
+												Relations</a></li>
+										<li><a href="http://business.metro.net" target="_blank">Suppliers +
+												Contractors</a></li>
+										<li><a href="https://developer.metro.net" target="_blank">Open Data +
+												Developers</a></li>
+									</ul>
+								</nav>
+							</div>
+
+							<div class="col-12 col-md-6 l-footer-linkset">
+								<nav>
+									<h4 class="js-footer-linkset-toggle">
+										<span>Information For...</span>
+										<svg class="svg-icon d-inline-block d-md-none" role="img" height="30"
+											width="30" focusable="false" viewBox="0 0 20 20">
+											<path d="M10 12.6L15.3 7l.7.7-6 6.3-6-6.3.7-.7z" fill="#3962ae"></path>
+										</svg>
+									</h4>
+									<ul class="l-footer-linkset__list" style="display: none;">
+										<li><a href="https://www.metro.net/riding/fares/" target="_self">Fares</a>
+										</li>
+										<li><a href="https://www.metro.net/riding/trip-planner/" target="_self">Trip
+												Planner</a></li>
+										<li><a href="https://www.metro.net/riding/nextrip/" target="_self">Nextrip
+												Arrivals</a></li>
+										<li><a href="https://www.metro.net/service/advisories/"
+												target="_self">Alerts + Advisories</a>
+										</li>
+										<li><a href="https://www.metro.net/riding/schedules/"
+												target="_self">Schedules &amp; Maps</a>
+										</li>
+										<li><a href="https://thesource.metro.net/2010/09/08/the-sources-comment-policy"
+												target="_blank">Comment Policy</a></li>
+										<li><a href="/mymetro " target="_blank">Employee Intranet</a></li>
+										<li><a href="http://fisesss.mta.net/OA_HTML/AppsLocalLogin.jsp"
+												target="_blank">Employee Self Service</a></li>
+									</ul>
+								</nav>
+							</div>
+
+						</div>
+					</div>
+				</div>
+
+				<div class="row">
+					<div class="col-12 col-md-6">
+						<nav class="l-footer-social cf">
+							<h4 class="visually-hidden">Social Networks</h4>
+							<ul class="list-inline">
+								<li class="list-inline-item">
+									<a href="http://twitter.com/#!/metrolosangeles" target="_blank" rel="noopener">
+										<span class="visually-hidden">Twitter</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#2D9DD4"
+												d="M84 73.4C84 79.2 79.2 84 73.4 84H10.6C4.8 84 0 79.2 0 73.4V10.6C0 4.8 4.8 0 10.6 0h62.8C79.2 0 84 4.8 84 10.6v62.8z">
+											</path>
+											<path fill="#fff"
+												d="M74.2 21.7c-2.4 1-4.9 1.8-7.6 2.1 2.7-1.6 4.8-4.2 5.8-7.3-2.5 1.5-5.4 2.6-8.4 3.2-2.4-2.6-5.8-4.2-9.6-4.2-7.3 0-13.2 5.9-13.2 13.2 0 1 .1 2 .3 3-11-.6-20.7-5.8-27.2-13.8-1.1 1.9-1.8 4.2-1.8 6.6 0 4.6 2.3 8.6 5.9 11-2.2-.1-4.2-.7-6-1.6v.2c0 6.4 4.6 11.7 10.6 13-1.1.3-2.3.5-3.5.5-.9 0-1.7-.1-2.5-.2 1.7 5.2 6.6 9.1 12.3 9.2-4.5 3.5-10.2 5.7-16.4 5.7-1.1 0-2.1-.1-3.1-.2 5.8 3.7 12.8 5.9 20.3 5.9 24.3 0 37.6-20.1 37.6-37.6v-1.7c2.5-2 4.7-4.3 6.5-7z">
+											</path>
+										</svg>
+									</a>
+								</li>
+								<li class="list-inline-item">
+									<a href="http://www.facebook.com/losangelesmetro" target="_blank"
+										rel="noopener">
+										<span class="visually-hidden">Facebook</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#3C5A98"
+												d="M84 73.4C84 79.3 79.2 84 73.4 84H10.6C4.8 84 0 79.3 0 73.4V10.6C0 4.8 4.8 0 10.6 0h62.8C79.2 0 84 4.8 84 10.6v62.8z">
+											</path>
+											<path fill="#fff"
+												d="M58 84V51.5h10.9l1.6-12.7H58v-8.1c0-3.7 1-6.2 6.3-6.2H71V13.2c-1.2-.2-5.2-.5-9.8-.5-9.7 0-16.3 5.9-16.3 16.8v9.4h-11v12.7h11V84H58z">
+											</path>
+										</svg>
+									</a>
+								</li>
+								<li class="list-inline-item">
+									<a href="https://www.instagram.com/metrolosangeles/" target="_blank"
+										rel="noopener">
+										<span class="visually-hidden">Instagram</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#D82B82"
+												d="M84 73.6C84 79.1 79.1 84 73.6 84H10.4C4.9 84 0 79.1 0 73.6V10.4C0 4.9 4.9 0 10.4 0h63.2C79.1 0 84 4.9 84 10.4v63.2z">
+											</path>
+											<g fill="#fff">
+												<path
+													d="M42.2 14.3c-15.3 0-27.7 12.4-27.7 27.7s12.4 27.7 27.7 27.7S69.9 57.3 69.9 42 57.5 14.3 42.2 14.3zm0 45.6c-9.9 0-18-8-18-18s8-18 18-18 18 8 18 18-8.1 18-18 18z">
+												</path>
+												<circle cx="71" cy="13.2" r="6.5"></circle>
+											</g>
+										</svg>
+									</a>
+								</li>
+								<li class="list-inline-item">
+									<a href="https://www.youtube.com/user/losangelesmetro" target="_blank"
+										rel="noopener">
+										<span class="visually-hidden">YouTube</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#E52027"
+												d="M84 73.6C84 79.1 79.1 84 73.6 84H10.4C4.9 84 0 79.1 0 73.6V10.4C0 4.9 4.9 0 10.4 0h63.2C79.1 0 84 4.9 84 10.4v63.2z">
+											</path>
+											<path fill="#fff"
+												d="M68.5 31.2s-.5-3.7-2.1-5.4c-2.1-2.2-4.4-2.2-5.4-2.3-7.6-.5-19-.5-19-.5s-11.3 0-18.9.5c-1.1.1-3.4.1-5.4 2.3-1.6 1.6-2.1 5.4-2.1 5.4s-.6 4.4-.6 8.7V44c0 4.4.5 8.7.5 8.7s.5 3.7 2.1 5.4c2.1 2.2 4.8 2.1 6 2.3 4.4.5 18.4.6 18.4.6s11.3 0 18.9-.6c1.1-.1 3.4-.1 5.4-2.3 1.6-1.6 2.1-5.4 2.1-5.4s.6-4.3.6-8.7v-4.1c0-4.3-.5-8.7-.5-8.7zM35.2 50.3V32.6l17 8.9-17 8.8z">
+											</path>
+										</svg>
+									</a>
+								</li>
+								<li class="list-inline-item">
+									<a href="http://www.linkedin.com/company/los-angeles-county-metropolitan-transportation-authority"
+										target="_blank" rel="noopener">
+										<span class="visually-hidden">LinkedIn</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#007BB5"
+												d="M84 73.4C84 79.2 79.2 84 73.4 84H10.6C4.8 84 0 79.2 0 73.4V10.6C0 4.8 4.8 0 10.6 0h62.8C79.2 0 84 4.8 84 10.6v62.8z">
+											</path>
+											<g fill="#fff">
+												<path
+													d="M12.4 31.5h12.5v40.1H12.4V31.5zm6.3-19.9c4 0 7.2 3.2 7.2 7.2S22.7 26 18.7 26s-7.2-3.2-7.2-7.2 3.2-7.2 7.2-7.2M32.7 31.5h11.9V37h.2c1.7-3.2 5.7-6.5 11.8-6.5 12.6 0 14.9 8.3 14.9 19.1v22H59.1V52.1c0-4.6-.1-10.6-6.5-10.6-6.5 0-7.5 5.1-7.5 10.3v19.8H32.7V31.5z">
+												</path>
+											</g>
+										</svg>
+									</a>
+								</li>
+								<li class="list-inline-item">
+									<a href="https://www.metro.net/news/metro-rss/"><span
+											class="visually-hidden">RSS</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#F17F21"
+												d="M84 73.4C84 79.2 79.2 84 73.4 84H10.6C4.8 84 0 79.2 0 73.4V10.6C0 4.8 4.8 0 10.6 0h62.8C79.2 0 84 4.8 84 10.6v62.8z">
+											</path>
+											<path fill="#fff"
+												d="M25.7 66.2c0 4.3-3.5 7.8-7.8 7.8s-7.8-3.5-7.8-7.8 3.5-7.8 7.8-7.8c4.3-.1 7.8 3.5 7.8 7.8zM47.9 74H37.6c-.1-7.3-3-14.2-8.2-19.4-5.2-5.2-12.1-8.1-19.4-8.3V36.1c20.8.3 37.6 17.1 37.9 37.9zM68 74H57.7C57.4 47.8 36.2 26.6 10 26.3V16c31.9.3 57.7 26.2 58 58z">
+											</path>
+										</svg>
+									</a>
+								</li>
+							</ul>
+						</nav>
+					</div>
+				</div>
+
+			</div><!-- end .site-content-wrapper -->
+		</div>
+	</div>
+	<div class="footer_row-2">
+		<div class="container-fluid d-flex flex-column flex-lg-row align-items-center py-3 px-lg-5">
+			<div class="col-12 col-lg-3 l-footer-buttonset">
+				<a href="https://www.metro.net/riding/riders-disabilities/" class="btn btn-xs btn-footer"><svg
+						class="svg-icon" role="img" height="34" width="22" focusable="false"
+						viewBox="0 0 30 30">
+						<path
+							d="M11.1 8.2v-.4c0-1.1.9-2 2-2s2 .9 2 2c0 1-.8 1.9-1.8 2l.2 3.2h4.7v1.8h-4.6l.1 1h5.9l.1.1 2.5 5.4 1.7-.8.7 1.5-3.5 1.6-2.6-5.9h-6.6zm7.2 13.3c-.9 2.1-3 3.5-5.3 3.5-3.2 0-5.7-2.5-5.7-5.7 0-2.1 1.2-4.1 3.1-5l.2-.1.2 1.8-.1.1c-1 .7-1.6 1.9-1.6 3.2 0 2.2 1.8 3.9 4 3.9s4-1.8 4-3.9v-1.1l1.3 3z"
+							fill="#fff"></path>
+					</svg> accessibility</a>
+			</div>
+			<div class="col-12 col-lg-6 l-footer-linkset l-footer-linkset--row-2">
+				<ul class="list-inline">
+					<li class="list-inline-item"><a href="https://www.metro.net/customercomments"
+							target="_blank">site feedback</a></li>
+					<li class="list-inline-item"><a
+							href="https://www.metro.net/about/site-information/site-map/">site map</a></li>
+					<li class="list-inline-item"><a
+							href="https://www.metro.net/about/site-information/copyright/">terms of use</a></li>
+					<li class="list-inline-item"><a
+							href="https://www.metro.net/about/site-information/privacy-policy/">privacy
+							policy</a></li>
+				</ul>
+			</div>
+			<div class="col-12 col-lg-3">
+				<div class="l-footer-copyright">Copyright 2021 Metro</div>
+			</div>
+		</div>
+	</div>
+</footer>
+<!---------------------- END FOOTER ---------------------->
+<script src="https://code.jquery.com/jquery-3.6.0.min.js" type="text/javascript"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"
+	integrity="sha384-p34f1UUtsS3wqzfto5wAAmdvj+osOnFyQFpp4Ua3gs/ZVWx6oOypYoCJhGGScy+8"
+	crossorigin="anonymous"></script>
+
+<!-- Google Translate -->
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"
+	defer></script>
+<script type="text/javascript" src="/js/common.js"></script>
+<script type="text/javascript" src="/js/index.js"></script>
+<!-- <script type="module" src="./js/typealhead.js"></script> -->
+<script type="text/javascript" src="/js/activecampaign.js"></script>
 </body>
 
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -179,6 +179,294 @@ rel="stylesheet">
 	vgo('process');
 </script>
 <!-- End Active Campaign tracking -->
+	<!---------------------- START FOOTER ---------------------->
+<footer>
+	<a class="l-footer--top" target="_self">
+		<span class="visually-hidden">Top of Page</span>
+		<svg class="svg-icon" role="img" height="40" width="40" focusable="false" viewBox="0 0 24 24">
+			<path
+				d="M12 1c6.1 0 11 5 11 11s-4.9 11-11 11S1 18.1 1 12 6 1 12 1m0-1C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.7 0 12 0z"
+				fill="#354ca0"></path>
+			<path
+				d="M12 1c6.1 0 11 5 11 11s-4.9 11-11 11S1 18.1 1 12 6 1 12 1m0-1C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.7 0 12 0z"
+				fill="#3c64ae"></path>
+			<path d="M12.5 7.4l3.9 4.1.6-.7-5-5.3-5 5.3.7.7 3.8-4.1v11.1h1z" fill="#3b63ae"></path>
+		</svg>
+	</a>
+	<div class="l-footer__row-1">
+		<div class="l-container">
+			<div class="site-content-wrapper">
+				<div class="row">
+					<div class="col-12 col-md-6">
+						<div class="l-footer-info">
+							<h4 class="l-footer-info__head">Bus & Rail Transit Info</h4>
+							<a href="tel:1-323-466-3876" class="l-footer-info__tel"
+								title="Call for Transit Info">323.GO.METRO <span
+									class="d-none d-sm-inline">(323.466.3876)</span></a>
+							<div class="l-footer-info__subtext">Mon-Fri 5am to 9pm <span
+									class="d-none d-sm-inline">|</span> <span class="d-block d-sm-inline">Sat/Sun
+									6am to 6pm</span></div>
+							<a href="tel:1-323-466-3876" class="l-footer-info__tel-icon d-md-none"><svg
+									class="svg-icon" role="img" height="50" width="50" focusable="false"
+									viewBox="0 0 24 24">
+									<path
+										d="M20.7 19.4c.3-.3.7-1-.1-2.1l-2.7-2.6s-.7-.7-1.7-.1l-.2.3zM9.6 8.7c.2-.1 1.1-1.2 0-2.3L6.9 3.8s-1-.7-1.9.2c0 0-.1 0-.2.1zm5.4 7.1l-.4.4s-4.4-2.3-6.2-6.2l.3-.3L4 5.2c-.5.9-1 2.3-.6 4 0 0 .1 3.4 6 8.6 0 0 3.2 2.8 6.8 3.3 0 0 1.8.4 3.5-.8z"
+										fill="#3962ae"></path>
+								</svg></a>
+						</div>
+						<div class="l-footer-info">
+							<h4 class="l-footer-info__head">Tap Customer Service</h4>
+							<a href="tel:1-866-827-8646" class="l-footer-info__tel"
+								title="Call for Transit Info">866.TAPTOGO</a>
+							<div class="l-footer-info__subtext"><span aria-hidden="true">Mon</span><span
+									class="visually-hidden">Monday</span>-<span aria-hidden="true">Fri</span><span
+									class="visually-hidden">Friday</span> 8am to 4:30pm | <a
+									href="https://www.taptogo.net" target="_blank" rel="noopener">Taptogo
+									Website</a></div>
+							<a href="tel:1-866-827-8646" class="l-footer-info__tel-icon d-md-none"><svg
+									class="svg-icon" role="img" height="50" width="50" focusable="false"
+									viewBox="0 0 24 24">
+									<path
+										d="M20.7 19.4c.3-.3.7-1-.1-2.1l-2.7-2.6s-.7-.7-1.7-.1l-.2.3zM9.6 8.7c.2-.1 1.1-1.2 0-2.3L6.9 3.8s-1-.7-1.9.2c0 0-.1 0-.2.1zm5.4 7.1l-.4.4s-4.4-2.3-6.2-6.2l.3-.3L4 5.2c-.5.9-1 2.3-.6 4 0 0 .1 3.4 6 8.6 0 0 3.2 2.8 6.8 3.3 0 0 1.8.4 3.5-.8z"
+										fill="#3962ae"></path>
+								</svg></a>
+						</div>
+						<div class="l-footer-info">
+							<h4 class="l-footer-info__head">Transit Watch <span class="d-inline"
+									aria-hidden="true">Metro Security</span></h4>
+							<a href="tel:1-888-950-7233" class="l-footer-info__tel"
+								title="Call for Transit Info">888.950.7233</a>
+							<div class="l-footer-info__subtext">24 hours | <a href="#">Report an Issue</a></div>
+							<a href="tel:1-888-950-7233" class="l-footer-info__tel-icon d-md-none"><svg
+									class="svg-icon" role="img" height="50" width="50" focusable="false"
+									viewBox="0 0 24 24">
+									<path
+										d="M20.7 19.4c.3-.3.7-1-.1-2.1l-2.7-2.6s-.7-.7-1.7-.1l-.2.3zM9.6 8.7c.2-.1 1.1-1.2 0-2.3L6.9 3.8s-1-.7-1.9.2c0 0-.1 0-.2.1zm5.4 7.1l-.4.4s-4.4-2.3-6.2-6.2l.3-.3L4 5.2c-.5.9-1 2.3-.6 4 0 0 .1 3.4 6 8.6 0 0 3.2 2.8 6.8 3.3 0 0 1.8.4 3.5-.8z"
+										fill="#3962ae"></path>
+								</svg></a>
+						</div>
+					</div>
+					<div class="col-12 col-md-6">
+						<div class="row l-footer-linksets">
+							<div class="col-12 col-md-6 l-footer-linkset">
+								<nav>
+									<h4 class="js-footer-linkset-toggle">
+										<span>Agency Links...</span>
+										<svg class="svg-icon d-inline-block d-md-none" role="img" height="30"
+											width="30" focusable="false" viewBox="0 0 20 20">
+											<path d="M10 12.6L15.3 7l.7.7-6 6.3-6-6.3.7-.7z" fill="#3962ae"></path>
+										</svg>
+									</h4>
+									<ul class="l-footer-linkset__list" style="display: none;">
+										<li><a href="https://www.metro.net/about/contact/" target="_self">Help &amp;
+												Contacts</a></li>
+										<li><a href="https://www.metro.net/about/contact/#customer-centers"
+												target="_self">Customer
+												Centers</a></li>
+										<li><a href="https://www.metro.net/about/careers/" target="_self">Metro
+												Careers</a></li>
+										<li><a href="https://boardagendas.metro.net/" target="_blank">Board
+												Meetings</a></li>
+										<li><a href="https://www.metro.net/about/board/recap-actions/"
+												target="_self">Board Recap of
+												Actions</a></li>
+										<li><a href="https://www.metro.net/news/media-relations-contact-information/"
+												target="_self">Media</a></li>
+										<li><a href="https://www.metrobonds.net" target="_blank">Investor
+												Relations</a></li>
+										<li><a href="http://business.metro.net" target="_blank">Suppliers +
+												Contractors</a></li>
+										<li><a href="https://developer.metro.net" target="_blank">Open Data +
+												Developers</a></li>
+									</ul>
+								</nav>
+							</div>
+
+							<div class="col-12 col-md-6 l-footer-linkset">
+								<nav>
+									<h4 class="js-footer-linkset-toggle">
+										<span>Information For...</span>
+										<svg class="svg-icon d-inline-block d-md-none" role="img" height="30"
+											width="30" focusable="false" viewBox="0 0 20 20">
+											<path d="M10 12.6L15.3 7l.7.7-6 6.3-6-6.3.7-.7z" fill="#3962ae"></path>
+										</svg>
+									</h4>
+									<ul class="l-footer-linkset__list" style="display: none;">
+										<li><a href="https://www.metro.net/riding/fares/" target="_self">Fares</a>
+										</li>
+										<li><a href="https://www.metro.net/riding/trip-planner/" target="_self">Trip
+												Planner</a></li>
+										<li><a href="https://www.metro.net/riding/nextrip/" target="_self">Nextrip
+												Arrivals</a></li>
+										<li><a href="https://www.metro.net/service/advisories/"
+												target="_self">Alerts + Advisories</a>
+										</li>
+										<li><a href="https://www.metro.net/riding/schedules/"
+												target="_self">Schedules &amp; Maps</a>
+										</li>
+										<li><a href="https://thesource.metro.net/2010/09/08/the-sources-comment-policy"
+												target="_blank">Comment Policy</a></li>
+										<li><a href="/mymetro " target="_blank">Employee Intranet</a></li>
+										<li><a href="http://fisesss.mta.net/OA_HTML/AppsLocalLogin.jsp"
+												target="_blank">Employee Self Service</a></li>
+									</ul>
+								</nav>
+							</div>
+
+						</div>
+					</div>
+				</div>
+
+				<div class="row">
+					<div class="col-12 col-md-6">
+						<nav class="l-footer-social cf">
+							<h4 class="visually-hidden">Social Networks</h4>
+							<ul class="list-inline">
+								<li class="list-inline-item">
+									<a href="http://twitter.com/#!/metrolosangeles" target="_blank" rel="noopener">
+										<span class="visually-hidden">Twitter</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#2D9DD4"
+												d="M84 73.4C84 79.2 79.2 84 73.4 84H10.6C4.8 84 0 79.2 0 73.4V10.6C0 4.8 4.8 0 10.6 0h62.8C79.2 0 84 4.8 84 10.6v62.8z">
+											</path>
+											<path fill="#fff"
+												d="M74.2 21.7c-2.4 1-4.9 1.8-7.6 2.1 2.7-1.6 4.8-4.2 5.8-7.3-2.5 1.5-5.4 2.6-8.4 3.2-2.4-2.6-5.8-4.2-9.6-4.2-7.3 0-13.2 5.9-13.2 13.2 0 1 .1 2 .3 3-11-.6-20.7-5.8-27.2-13.8-1.1 1.9-1.8 4.2-1.8 6.6 0 4.6 2.3 8.6 5.9 11-2.2-.1-4.2-.7-6-1.6v.2c0 6.4 4.6 11.7 10.6 13-1.1.3-2.3.5-3.5.5-.9 0-1.7-.1-2.5-.2 1.7 5.2 6.6 9.1 12.3 9.2-4.5 3.5-10.2 5.7-16.4 5.7-1.1 0-2.1-.1-3.1-.2 5.8 3.7 12.8 5.9 20.3 5.9 24.3 0 37.6-20.1 37.6-37.6v-1.7c2.5-2 4.7-4.3 6.5-7z">
+											</path>
+										</svg>
+									</a>
+								</li>
+								<li class="list-inline-item">
+									<a href="http://www.facebook.com/losangelesmetro" target="_blank"
+										rel="noopener">
+										<span class="visually-hidden">Facebook</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#3C5A98"
+												d="M84 73.4C84 79.3 79.2 84 73.4 84H10.6C4.8 84 0 79.3 0 73.4V10.6C0 4.8 4.8 0 10.6 0h62.8C79.2 0 84 4.8 84 10.6v62.8z">
+											</path>
+											<path fill="#fff"
+												d="M58 84V51.5h10.9l1.6-12.7H58v-8.1c0-3.7 1-6.2 6.3-6.2H71V13.2c-1.2-.2-5.2-.5-9.8-.5-9.7 0-16.3 5.9-16.3 16.8v9.4h-11v12.7h11V84H58z">
+											</path>
+										</svg>
+									</a>
+								</li>
+								<li class="list-inline-item">
+									<a href="https://www.instagram.com/metrolosangeles/" target="_blank"
+										rel="noopener">
+										<span class="visually-hidden">Instagram</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#D82B82"
+												d="M84 73.6C84 79.1 79.1 84 73.6 84H10.4C4.9 84 0 79.1 0 73.6V10.4C0 4.9 4.9 0 10.4 0h63.2C79.1 0 84 4.9 84 10.4v63.2z">
+											</path>
+											<g fill="#fff">
+												<path
+													d="M42.2 14.3c-15.3 0-27.7 12.4-27.7 27.7s12.4 27.7 27.7 27.7S69.9 57.3 69.9 42 57.5 14.3 42.2 14.3zm0 45.6c-9.9 0-18-8-18-18s8-18 18-18 18 8 18 18-8.1 18-18 18z">
+												</path>
+												<circle cx="71" cy="13.2" r="6.5"></circle>
+											</g>
+										</svg>
+									</a>
+								</li>
+								<li class="list-inline-item">
+									<a href="https://www.youtube.com/user/losangelesmetro" target="_blank"
+										rel="noopener">
+										<span class="visually-hidden">YouTube</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#E52027"
+												d="M84 73.6C84 79.1 79.1 84 73.6 84H10.4C4.9 84 0 79.1 0 73.6V10.4C0 4.9 4.9 0 10.4 0h63.2C79.1 0 84 4.9 84 10.4v63.2z">
+											</path>
+											<path fill="#fff"
+												d="M68.5 31.2s-.5-3.7-2.1-5.4c-2.1-2.2-4.4-2.2-5.4-2.3-7.6-.5-19-.5-19-.5s-11.3 0-18.9.5c-1.1.1-3.4.1-5.4 2.3-1.6 1.6-2.1 5.4-2.1 5.4s-.6 4.4-.6 8.7V44c0 4.4.5 8.7.5 8.7s.5 3.7 2.1 5.4c2.1 2.2 4.8 2.1 6 2.3 4.4.5 18.4.6 18.4.6s11.3 0 18.9-.6c1.1-.1 3.4-.1 5.4-2.3 1.6-1.6 2.1-5.4 2.1-5.4s.6-4.3.6-8.7v-4.1c0-4.3-.5-8.7-.5-8.7zM35.2 50.3V32.6l17 8.9-17 8.8z">
+											</path>
+										</svg>
+									</a>
+								</li>
+								<li class="list-inline-item">
+									<a href="http://www.linkedin.com/company/los-angeles-county-metropolitan-transportation-authority"
+										target="_blank" rel="noopener">
+										<span class="visually-hidden">LinkedIn</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#007BB5"
+												d="M84 73.4C84 79.2 79.2 84 73.4 84H10.6C4.8 84 0 79.2 0 73.4V10.6C0 4.8 4.8 0 10.6 0h62.8C79.2 0 84 4.8 84 10.6v62.8z">
+											</path>
+											<g fill="#fff">
+												<path
+													d="M12.4 31.5h12.5v40.1H12.4V31.5zm6.3-19.9c4 0 7.2 3.2 7.2 7.2S22.7 26 18.7 26s-7.2-3.2-7.2-7.2 3.2-7.2 7.2-7.2M32.7 31.5h11.9V37h.2c1.7-3.2 5.7-6.5 11.8-6.5 12.6 0 14.9 8.3 14.9 19.1v22H59.1V52.1c0-4.6-.1-10.6-6.5-10.6-6.5 0-7.5 5.1-7.5 10.3v19.8H32.7V31.5z">
+												</path>
+											</g>
+										</svg>
+									</a>
+								</li>
+								<li class="list-inline-item">
+									<a href="https://www.metro.net/news/metro-rss/"><span
+											class="visually-hidden">RSS</span>
+										<svg class="svg-icon" role="img" height="34" width="34" focusable="false"
+											viewBox="0 0 84 84">
+											<path fill="#F17F21"
+												d="M84 73.4C84 79.2 79.2 84 73.4 84H10.6C4.8 84 0 79.2 0 73.4V10.6C0 4.8 4.8 0 10.6 0h62.8C79.2 0 84 4.8 84 10.6v62.8z">
+											</path>
+											<path fill="#fff"
+												d="M25.7 66.2c0 4.3-3.5 7.8-7.8 7.8s-7.8-3.5-7.8-7.8 3.5-7.8 7.8-7.8c4.3-.1 7.8 3.5 7.8 7.8zM47.9 74H37.6c-.1-7.3-3-14.2-8.2-19.4-5.2-5.2-12.1-8.1-19.4-8.3V36.1c20.8.3 37.6 17.1 37.9 37.9zM68 74H57.7C57.4 47.8 36.2 26.6 10 26.3V16c31.9.3 57.7 26.2 58 58z">
+											</path>
+										</svg>
+									</a>
+								</li>
+							</ul>
+						</nav>
+					</div>
+				</div>
+
+			</div><!-- end .site-content-wrapper -->
+		</div>
+	</div>
+	<div class="footer_row-2">
+		<div class="container-fluid d-flex flex-column flex-lg-row align-items-center py-3 px-lg-5">
+			<div class="col-12 col-lg-3 l-footer-buttonset">
+				<a href="https://www.metro.net/riding/riders-disabilities/" class="btn btn-xs btn-footer"><svg
+						class="svg-icon" role="img" height="34" width="22" focusable="false"
+						viewBox="0 0 30 30">
+						<path
+							d="M11.1 8.2v-.4c0-1.1.9-2 2-2s2 .9 2 2c0 1-.8 1.9-1.8 2l.2 3.2h4.7v1.8h-4.6l.1 1h5.9l.1.1 2.5 5.4 1.7-.8.7 1.5-3.5 1.6-2.6-5.9h-6.6zm7.2 13.3c-.9 2.1-3 3.5-5.3 3.5-3.2 0-5.7-2.5-5.7-5.7 0-2.1 1.2-4.1 3.1-5l.2-.1.2 1.8-.1.1c-1 .7-1.6 1.9-1.6 3.2 0 2.2 1.8 3.9 4 3.9s4-1.8 4-3.9v-1.1l1.3 3z"
+							fill="#fff"></path>
+					</svg> accessibility</a>
+			</div>
+			<div class="col-12 col-lg-6 l-footer-linkset l-footer-linkset--row-2">
+				<ul class="list-inline">
+					<li class="list-inline-item"><a href="https://www.metro.net/customercomments"
+							target="_blank">site feedback</a></li>
+					<li class="list-inline-item"><a
+							href="https://www.metro.net/about/site-information/site-map/">site map</a></li>
+					<li class="list-inline-item"><a
+							href="https://www.metro.net/about/site-information/copyright/">terms of use</a></li>
+					<li class="list-inline-item"><a
+							href="https://www.metro.net/about/site-information/privacy-policy/">privacy
+							policy</a></li>
+				</ul>
+			</div>
+			<div class="col-12 col-lg-3">
+				<div class="l-footer-copyright">Copyright 2021 Metro</div>
+			</div>
+		</div>
+	</div>
+</footer>
+<!---------------------- END FOOTER ---------------------->
+<script src="https://code.jquery.com/jquery-3.6.0.min.js" type="text/javascript"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"
+	integrity="sha384-p34f1UUtsS3wqzfto5wAAmdvj+osOnFyQFpp4Ua3gs/ZVWx6oOypYoCJhGGScy+8"
+	crossorigin="anonymous"></script>
+
+<!-- Google Translate -->
+<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"
+	defer></script>
+<script type="text/javascript" src="/js/common.js"></script>
+<script type="text/javascript" src="/js/index.js"></script>
+<!-- <script type="module" src="./js/typealhead.js"></script> -->
+<script type="text/javascript" src="/js/activecampaign.js"></script>
 </body>
 
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -128,17 +128,41 @@ rel="stylesheet">
 						<h1 class="pt-lg-5 pb-lg-3 px-lg-5">Is my bus line changing?</h1>
 
 						
-								<p class="pb-lg-3 px-lg-5">
-	Metro has made service changes to bus lines on Sunday, June 26, to provide riders with more reliable and predictable service.
-</p>
-
-<hr class="d-none d-lg-block">
-<div class="py-lg-4">
+								<div class="_form_75">
 	<div>
-		<a type="button" class="btn btn-dark col-12 mb-4 cta" id="requestAllChanges" href="/allChanges">See Updates</a>
+		<p>
+			Metro is relentlessly focused on making your bus system better. Get advanced notice of future improvements to your bus line.
+		</p>
+		<form method="POST" action="https://metro77073.activehosted.com/proc.php" id="_form_75_"
+			class="_form _form_75 _inline-form" novalidate>
+			<input type="hidden" name="u" value="75" />
+			<input type="hidden" name="f" value="75" />
+			<input type="hidden" name="s" />
+			<input type="hidden" name="c" value="0" />
+			<input type="hidden" name="m" value="0" />
+			<input type="hidden" name="act" value="sub" />
+			<input type="hidden" name="v" value="2" />
+
+			<div class="_form-content">
+				<div class="_form_element _x68633660">
+					<div class="_field-wrapper">
+						<input type="text" id="email" name="email" placeholder="Enter email address" required />
+					</div>
+				</div>
+				<div class="_button-wrapper">
+					<button id="_form_75_submit" class="_submit mb-4" type="submit">
+						Sign up
+					</button>
+				</div>
+				<div class="_clear-element">
+				</div>
+			</div>
+			<div class="_form-thank-you" style="display:none;">
+			</div>
+		</form>
 	</div>
 </div>
-							
+						
 
 					</div>
 				</div>

--- a/src/_includes/default.liquid
+++ b/src/_includes/default.liquid
@@ -18,6 +18,7 @@ siteTitle: "Is my bus line changing?"
 	{{ content }}
 
 	{% include 'tracking/footer' %}
+	{% include 'footer' %}
 </body>
 
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -1,8 +1,9 @@
 ---
 layout: default
-mode: 'all'
+mode: 'email'
 # modes: 'email', 'all', 'select'
-message: 'Metro has made service changes to bus lines on Sunday, June 26, to provide riders with more reliable and predictable service.'
+message: 'Metro is relentlessly focused on making your bus system better. Get advanced notice of future improvements to your bus line.'
+# 'Metro has made service changes to bus lines on Sunday, June 26, to provide riders with more reliable and predictable service.'
 # 'Metro is making service changes to bus lines starting on Sunday, June 26, to provide riders with more reliable and predictable service. Get advanced notice of the upcoming improvements to your bus line.'
 # 'Metro is relentlessly focused on making your bus system better. Get advanced notice of future improvements to your bus line.'
 css: 


### PR DESCRIPTION
closes #5 

Changes:
- updated the `mode` value in `index.html` to email so that the page shows the email collection form
- updated the message shown to match
- added CNAME to the passthrough code in `.eleventy.js` so that it gets built to `docs/`, which is needed for GitHub Pages to work with a custom domain